### PR TITLE
Update Schedule Next to support current time to calculate next activation time

### DIFF
--- a/constantdelay.go
+++ b/constantdelay.go
@@ -22,14 +22,31 @@ func Every(duration time.Duration) ConstantDelaySchedule {
 
 // Next returns the next time this should be run.
 // This rounds so that the next activation time will be on the second.
-// If `after` time is specified then the next activation time later than
-// `after` is calculated.
-func (schedule ConstantDelaySchedule) Next(from, after time.Time) time.Time {
+// t is the time instant to calculate the next instant from.
+func (schedule ConstantDelaySchedule) Next(t time.Time) time.Time {
+	return schedule.NextWithAfter(t, time.Time{})
+}
+
+// NextWithAfter returns the next time this should be run which is later than the provided `after`.
+// This method calculates the next activation time by adding the delay to the `from` time param.
+// If `after` time specified is non-zero and later than `from`, then the diff between them is
+// calculated. This time difference is divided by the schedule delay interval to round off to the
+// nearest multiple that should be added to `from` to bring it closest to `after`. The delay interval
+// is added once more to get the new time which will be guaranteed to be later than `after`.
+// Note: additional nanoseconds are rounded off to the nearest second.
+//
+// `from` is the starting time instant to calculate the delay from.
+// `after` is the time instant the new calculated next should be later than.
+// TFROM + delay*M = TNEXT such that TNEXT  is after TAFTER
+func (schedule ConstantDelaySchedule) NextWithAfter(from, after time.Time) time.Time {
 	if after.IsZero() || after.Before(from) {
 		return from.Add(schedule.Delay - time.Duration(from.Nanosecond())*time.Nanosecond)
 	} else {
+		// calculate total delay between start and from
 		diff := after.Sub(from) + time.Duration(from.Nanosecond())*time.Nanosecond
+		// find the lowest multiple of delay that needs to be added to from
 		timeDelay := (diff / schedule.Delay) * schedule.Delay
+		// add another round delay and round off nanoseconds to get the nearest second
 		return from.Add(timeDelay).Add(schedule.Delay - time.Duration(from.Nanosecond())*time.Nanosecond)
 	}
 }

--- a/constantdelay.go
+++ b/constantdelay.go
@@ -22,6 +22,14 @@ func Every(duration time.Duration) ConstantDelaySchedule {
 
 // Next returns the next time this should be run.
 // This rounds so that the next activation time will be on the second.
-func (schedule ConstantDelaySchedule) Next(t time.Time) time.Time {
-	return t.Add(schedule.Delay - time.Duration(t.Nanosecond())*time.Nanosecond)
+// If `after` time is specified then the next activation time later than
+// `after` is calculated.
+func (schedule ConstantDelaySchedule) Next(from, after time.Time) time.Time {
+	if after.IsZero() || after.Before(from) {
+		return from.Add(schedule.Delay - time.Duration(from.Nanosecond())*time.Nanosecond)
+	} else {
+		diff := after.Sub(from) + time.Duration(from.Nanosecond())*time.Nanosecond
+		timeDelay := (diff / schedule.Delay) * schedule.Delay
+		return from.Add(timeDelay).Add(schedule.Delay - time.Duration(from.Nanosecond())*time.Nanosecond)
+	}
 }

--- a/constantdelay_test.go
+++ b/constantdelay_test.go
@@ -66,6 +66,9 @@ func TestConstantDelayNextWithAfter(t *testing.T) {
 		{"Mon Jul 9 14:59 2012", 15 * time.Minute, "Mon Jul 9 15:15:00.005 2012", "Mon Jul 9 15:29 2012"},
 		{"Mon Jul 9 14:59:59 2012", 15 * time.Minute, "Mon Jul 9 15:15 2012", "Mon Jul 9 15:29:59 2012"},
 
+		// Simple case with from and after having same value
+		{"Mon Jul 9 14:45 2012", 15 * time.Minute, "Mon Jul 9 14:45:00 2012", "Mon Jul 9 15:00 2012"},
+
 		// Wrap around hours
 		{"Mon Jul 9 15:45 2012", 35 * time.Minute, "Mon Jul 9 17:00 2012", "Mon Jul 9 17:30 2012"},
 

--- a/constantdelay_test.go
+++ b/constantdelay_test.go
@@ -45,7 +45,7 @@ func TestConstantDelayNext(t *testing.T) {
 	}
 
 	for _, c := range tests {
-		actual := Every(c.delay).Next(getTime(c.time), time.Time{})
+		actual := Every(c.delay).Next(getTime(c.time))
 		expected := getTime(c.expected)
 		if actual != expected {
 			t.Errorf("%s, \"%s\": (expected) %v != %v (actual)", c.time, c.delay, expected, actual)
@@ -93,7 +93,7 @@ func TestConstantDelayNextWithAfter(t *testing.T) {
 	}
 
 	for _, c := range tests {
-		actual := Every(c.delay).Next(getTime(c.time), getTime(c.after))
+		actual := Every(c.delay).NextWithAfter(getTime(c.time), getTime(c.after))
 		expected := getTime(c.expected)
 		if actual != expected {
 			t.Errorf("%s, \"%s\": (expected) %v != %v (actual)", c.time, c.delay, expected, actual)

--- a/constantdelay_test.go
+++ b/constantdelay_test.go
@@ -45,7 +45,55 @@ func TestConstantDelayNext(t *testing.T) {
 	}
 
 	for _, c := range tests {
-		actual := Every(c.delay).Next(getTime(c.time))
+		actual := Every(c.delay).Next(getTime(c.time), time.Time{})
+		expected := getTime(c.expected)
+		if actual != expected {
+			t.Errorf("%s, \"%s\": (expected) %v != %v (actual)", c.time, c.delay, expected, actual)
+		}
+	}
+}
+
+func TestConstantDelayNextWithAfter(t *testing.T) {
+	tests := []struct {
+		time     string
+		delay    time.Duration
+		after    string
+		expected string
+	}{
+		// Simple cases
+		{"Mon Jul 9 14:45 2012", 15*time.Minute + 50*time.Nanosecond, "Mon Jul 9 15:15:00.005 2012", "Mon Jul 9 15:30 2012"},
+		{"Mon Jul 9 14:45 2012", 15*time.Minute + 50*time.Nanosecond, "Mon Jul 9 15:27 2015", "Mon Jul 9 15:30 2015"},
+		{"Mon Jul 9 14:59 2012", 15 * time.Minute, "Mon Jul 9 15:15:00.005 2012", "Mon Jul 9 15:29 2012"},
+		{"Mon Jul 9 14:59:59 2012", 15 * time.Minute, "Mon Jul 9 15:15 2012", "Mon Jul 9 15:29:59 2012"},
+
+		// Wrap around hours
+		{"Mon Jul 9 15:45 2012", 35 * time.Minute, "Mon Jul 9 17:00 2012", "Mon Jul 9 17:30 2012"},
+
+		// Wrap around days
+		{"Mon Jul 9 23:48 2012", 14 * time.Minute, "Tue Jul 10 00:00 2012", "Tue Jul 10 00:02 2012"},
+		{"Mon Jul 9 23:45 2012", 35 * time.Minute, "Tue Jul 10 00:00 2012", "Tue Jul 10 00:20 2012"},
+		{"Mon Jul 9 23:35:51 2012", 44*time.Minute + 24*time.Second, "Tue Jul 10 00:30:00 2012", "Tue Jul 10 01:04:39 2012"},
+		{"Mon Jul 9 23:35:51 2012", 25*time.Hour + 44*time.Minute + 24*time.Second, "Thu Jul 10 12:00:00 2012", "Thu Jul 11 01:20:15 2012"},
+
+		// Wrap around months
+		{"Mon Jul 9 23:35 2012", 91*24*time.Hour + 25*time.Minute, "Thu Oct 11 00:00 2012", "Mon Jan 07 23:25 2013"},
+
+		// Wrap around minute, hour, day, month, and year
+		{"Mon Dec 31 23:59:45 2012", 15 * time.Minute, "Tue Jan 1 12:00:00 2013", "Tue Jan 1 12:14:45 2013"},
+
+		// Round to the nearest second on the delay
+		{"Mon Jul 9 14:45 2012", 15*time.Minute + 50*time.Nanosecond, "Mon Jul 9 16:00 2012", "Mon Jul 9 16:15 2012"},
+
+		// Round to the nearest second when calculating the next time.
+		{"Mon Jul 9 14:45:00.005 2012", 15 * time.Minute, "Mon Jul 9 15:25 2012", "Mon Jul 9 15:30 2012"},
+
+		// Round to the nearest second for both.
+		{"Mon Jul 9 14:45:00.005 2012", 15*time.Minute + 50*time.Nanosecond, "", "Mon Jul 9 15:00 2012"},
+		{"Mon Jul 9 14:45:00.005 2012", 15*time.Minute + 50*time.Nanosecond, "Mon Jul 9 15:30 2012", "Mon Jul 9 15:45 2012"},
+	}
+
+	for _, c := range tests {
+		actual := Every(c.delay).Next(getTime(c.time), getTime(c.after))
 		expected := getTime(c.expected)
 		if actual != expected {
 			t.Errorf("%s, \"%s\": (expected) %v != %v (actual)", c.time, c.delay, expected, actual)

--- a/cron.go
+++ b/cron.go
@@ -310,10 +310,10 @@ func (c *Cron) run(ctx context.Context) {
 					if e.Next.After(now) || e.Next.IsZero() {
 						break
 					}
-					c.startJob(ctx, e.WrappedJob)
 					e.Prev = e.Next
 					e.Next = e.Schedule.Next(now)
 					e.AdHocInvokedTime = time.Time{} // reset the adhoc invoked time if it was set previous to this run.
+					c.startJob(ctx, e.WrappedJob)
 					c.logger.Info("run", "now", now, "entry", e.ID, "next", e.Next)
 				}
 

--- a/cron_test.go
+++ b/cron_test.go
@@ -544,7 +544,7 @@ func TestScheduleAfterRemoval(t *testing.T) {
 
 type ZeroSchedule struct{}
 
-func (*ZeroSchedule) Next(time.Time) time.Time {
+func (*ZeroSchedule) Next(from, after time.Time) time.Time {
 	return time.Time{}
 }
 

--- a/cron_test.go
+++ b/cron_test.go
@@ -544,7 +544,10 @@ func TestScheduleAfterRemoval(t *testing.T) {
 
 type ZeroSchedule struct{}
 
-func (*ZeroSchedule) Next(from, after time.Time) time.Time {
+func (*ZeroSchedule) Next(from time.Time) time.Time {
+	return time.Time{}
+}
+func (*ZeroSchedule) NextWithAfter(from, after time.Time) time.Time {
 	return time.Time{}
 }
 

--- a/spec.go
+++ b/spec.go
@@ -53,11 +53,17 @@ const (
 	starBit = 1 << 63
 )
 
-// Next returns the next time this schedule is activated, greater than the given
+// Next returns the next time this schedule is activated.
+// `from` is the starting time instant to begin the delay calculation.
+func (s *SpecSchedule) Next(from time.Time) time.Time {
+	return s.NextWithAfter(from, time.Time{})
+}
+
+// NextWithAfter returns the next time this schedule is activated, greater than the given
 // time.  If no time can be found to satisfy the schedule, return the zero time.
 // If `after` time is specified then the next activation time which is later than
 // `after` is returned.
-func (s *SpecSchedule) Next(t time.Time, after time.Time) time.Time {
+func (s *SpecSchedule) NextWithAfter(t, after time.Time) time.Time {
 	// General approach
 	//
 	// For Month, Day, Hour, Minute, Second:

--- a/spec.go
+++ b/spec.go
@@ -55,7 +55,9 @@ const (
 
 // Next returns the next time this schedule is activated, greater than the given
 // time.  If no time can be found to satisfy the schedule, return the zero time.
-func (s *SpecSchedule) Next(t time.Time) time.Time {
+// If `after` time is specified then the next activation time which is later than
+// `after` is returned.
+func (s *SpecSchedule) Next(t time.Time, after time.Time) time.Time {
 	// General approach
 	//
 	// For Month, Day, Hour, Minute, Second:
@@ -69,6 +71,9 @@ func (s *SpecSchedule) Next(t time.Time) time.Time {
 	// Save the original timezone so we can convert back after we find a time.
 	// Note that schedules without a time zone specified (time.Local) are treated
 	// as local to the time provided.
+	if !after.IsZero() && after.After(t) {
+		t = after
+	}
 	origLocation := t.Location()
 	loc := s.Location
 	if loc == time.Local {

--- a/spec_test.go
+++ b/spec_test.go
@@ -62,7 +62,7 @@ func TestActivation(t *testing.T) {
 			t.Error(err)
 			continue
 		}
-		actual := sched.Next(getTime(test.time).Add(-1 * time.Second))
+		actual := sched.Next(getTime(test.time).Add(-1*time.Second), time.Time{})
 		expected := getTime(test.time)
 		if test.expected && expected != actual || !test.expected && expected == actual {
 			t.Errorf("Fail evaluating %s on %s: (expected) %s != %s (actual)",
@@ -191,7 +191,97 @@ func TestNext(t *testing.T) {
 			t.Error(err)
 			continue
 		}
-		actual := sched.Next(getTime(c.time))
+		actual := sched.Next(getTime(c.time), time.Time{})
+		expected := getTime(c.expected)
+		if !actual.Equal(expected) {
+			t.Errorf("%s, \"%s\": (expected) %v != %v (actual)", c.time, c.spec, expected, actual)
+		}
+	}
+}
+
+func TestNextAfterTime(t *testing.T) {
+	runs := []struct {
+		time, spec, after string
+		expected          string
+	}{
+		// Simple cases
+		{"Mon Jul 9 14:45 2012", "0 0/15 * * * *", "Mon Jul 9 15:30 2012", "Mon Jul 9 15:45 2012"},
+		{"Mon Jul 9 14:59 2012", "0 0/15 * * * *", "Wed Jul 11 15:30 2012", "Wed Jul 11 15:45 2012"},
+		{"Mon Jul 9 14:59:59 2012", "0 0/15 * * * *", "Wed Jul 11 15:00 2012", "Wed Jul 11 15:15 2012"},
+
+		// Wrap around hours
+		{"Mon Jul 9 15:45 2012", "0 20-35/15 * * * *", "Wed Jul 11 16:36 2012", "Wed Jul 11 17:20 2012"},
+
+		// Wrap around days
+		{"Mon Jul 9 23:46 2012", "0 */15 * * * *", "Tue Jul 10 08:00 2012", "Tue Jul 10 08:15 2012"},
+		{"Mon Jul 9 23:45 2012", "0 20-35/15 * * * *", "Tue Jul 10 08:00 2012", "Tue Jul 10 08:20 2012"},
+		{"Mon Jul 9 23:35:51 2012", "15/35 20-35/15 * * * *", "Tue Jul 10 08:00 2012", "Tue Jul 10 08:20:15 2012"},
+		{"Mon Jul 9 23:35:51 2012", "15/35 20-35/15 1/2 * * *", "Wed Jul 11 00:00 2012", "Wed Jul 11 01:20:15 2012"},
+		{"Mon Jul 9 23:35:51 2012", "15/35 20-35/15 10-12 * * *", "Tue Jul 10 00:00 2012", "Tue Jul 10 10:20:15 2012"},
+		{"Mon Jul 9 23:35:51 2012", "15/35 20-35/15 1/2 */2 * *", "Wed Jul 11 04:00:00 2012", "Wed Jul 11 05:20:15 2012"},
+
+		// Wrap around months
+		{"Mon Jul 9 23:35:51 2012", "15/35 20-35/15 * 9-20 Jul *", "", "Wed Jul 10 00:20:15 2012"},
+		{"Mon Jul 9 23:35:51 2012", "15/35 20-35/15 * 9-20 * *", "Wed Jul 30 23:59:55 2012", "Wed Aug 09 00:20:15 2012"},
+		{"Mon Jul 9 23:35 2012", "0 0 0 9 Apr-Oct ?", "Thu Aug 9 00:00 2012", "Wed Sep 9 00:00 2012"},
+		{"Mon Jul 9 23:35 2012", "0 0 0 */5 Apr,Aug,Oct Mon", "Tue Aug 2 00:00 2012", "Tue Aug 6 00:00 2012"},
+		{"Mon Jul 9 23:35 2012", "0 0 0 */5 Oct Mon", "", "Mon Oct 1 00:00 2012"},
+
+		// Wrap around years
+		{"Mon Jul 9 23:35 2012", "0 0 0 * Feb Mon", "Mon Feb 5 00:00 2013", "Mon Feb 11 00:00 2013"},
+		{"Mon Jul 9 23:35 2012", "0 0 0 * Feb Mon/2", "Mon Feb 4 00:00 2013", "Mon Feb 6 00:00 2013"},
+
+		// Wrap around minute, hour, day, month, and year
+		{"Mon Dec 31 23:59:45 2012", "0 * * * * *", "Wed Jan 2 10:00:00 2013", "Wed Jan 2 10:01:00 2013"},
+
+		// Leap year
+		{"Mon Jul 9 23:35 2012", "0 0 0 29 Feb ?", "Mon Feb 29 00:00:00.001 2016", "Mon Feb 29 00:00 2020"},
+
+		// Daylight savings time 2am EST (-5) -> 3am EDT (-4)
+		{"2012-03-11T00:00:00-0500", "TZ=America/New_York 0 30 2 11 Mar ?", "2013-03-11T01:15:00-0500", "2013-03-11T02:30:00-0400"},
+
+		// hourly job
+		{"2012-03-11T00:00:00-0500", "TZ=America/New_York 0 0 * * * ?", "2012-03-11T01:30:00-0400", "2012-03-11T02:00:00-0400"},
+		{"2012-03-11T01:00:00-0500", "TZ=America/New_York 0 0 * * * ?", "", "2012-03-11T03:00:00-0400"},
+
+		// hourly job using CRON_TZ
+		{"2012-03-11T00:00:00-0500", "CRON_TZ=America/New_York 0 0 * * * ?", "", "2012-03-11T01:00:00-0500"},
+		{"2012-03-11T01:00:00-0500", "CRON_TZ=America/New_York 0 0 * * * ?", "", "2012-03-11T03:00:00-0400"},
+		{"2012-03-11T02:00:00-0400", "CRON_TZ=America/New_York 0 0 * * * ?", "2012-03-11T02:00:00-0400", "2012-03-11T03:00:00-0400"},
+		{"2012-03-11T04:00:00-0400", "CRON_TZ=America/New_York 0 0 * * * ?", "", "2012-03-11T05:00:00-0400"},
+
+		// Daylight savings time 2am EDT (-4) => 1am EST (-5)
+		{"2012-11-04T00:00:00-0400", "TZ=America/New_York 0 30 2 04 Nov ?", "", "2012-11-04T02:30:00-0500"},
+		{"2012-11-04T01:45:00-0400", "TZ=America/New_York 0 30 1 04 Nov ?", "2012-11-04T01:59:00-0400", "2012-11-04T01:30:00-0500"},
+
+		// hourly job
+		{"2012-11-04T00:00:00-0400", "TZ=America/New_York 0 0 * * * ?", "", "2012-11-04T01:00:00-0400"},
+		{"2012-11-04T01:00:00-0400", "TZ=America/New_York 0 0 * * * ?", "2012-11-04T01:00:00-0500", "2012-11-04T02:00:00-0500"},
+		{"TZ=America/New_York 2012-11-04T01:00:00-0500", "0 0 1 * * ?", "2012-11-05T12:00:00-0500", "2012-11-06T01:00:00-0500"},
+		{"TZ=America/New_York 2012-11-04T03:00:00-0500", "0 0 3 * * ?", "2012-11-05T12:00:00-0500", "2012-11-06T03:00:00-0500"},
+
+		// Unsatisfiable
+		{"Mon Jul 9 23:35 2012", "0 0 0 30 Feb ?", "Mon Jul 9 23:35 2019", ""},
+		{"Mon Jul 9 23:35 2012", "0 0 0 31 Apr ?", "Mon Jul 9 23:35 2012", ""},
+
+		// Monthly job
+		{"TZ=America/New_York 2012-11-04T00:00:00-0400", "0 0 3 3 * ?", "2012-12-03T10:00:00-0500", "2013-01-03T03:00:00-0500"},
+
+		// Test the scenario of DST resulting in midnight not being a valid time.
+		// https://github.com/robfig/cron/issues/157
+		{"2018-10-17T05:00:00-0400", "TZ=America/Sao_Paulo 0 0 9 10 * ?", "", "2018-11-10T06:00:00-0500"},
+		{"2018-10-17T05:00:00-0400", "TZ=America/Sao_Paulo 0 0 9 10 * ?", "2018-11-12T07:00:00-0500", "2018-12-10T06:00:00-0500"},
+		{"2018-02-14T05:00:00-0500", "TZ=America/Sao_Paulo 0 0 9 22 * ?", "", "2018-02-22T07:00:00-0500"},
+		{"2018-02-14T05:00:00-0500", "TZ=America/Sao_Paulo 0 0 9 22 * ?", "2018-02-23T07:00:00-0500", "2018-03-22T07:00:00-0500"},
+	}
+
+	for _, c := range runs {
+		sched, err := secondParser.Parse(c.spec)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+		actual := sched.Next(getTime(c.time), getTime(c.after))
 		expected := getTime(c.expected)
 		if !actual.Equal(expected) {
 			t.Errorf("%s, \"%s\": (expected) %v != %v (actual)", c.time, c.spec, expected, actual)
@@ -264,7 +354,7 @@ func TestNextWithTz(t *testing.T) {
 			t.Error(err)
 			continue
 		}
-		actual := sched.Next(getTimeTZ(c.time))
+		actual := sched.Next(getTimeTZ(c.time), time.Time{})
 		expected := getTimeTZ(c.expected)
 		if !actual.Equal(expected) {
 			t.Errorf("%s, \"%s\": (expected) %v != %v (actual)", c.time, c.spec, expected, actual)

--- a/spec_test.go
+++ b/spec_test.go
@@ -62,7 +62,7 @@ func TestActivation(t *testing.T) {
 			t.Error(err)
 			continue
 		}
-		actual := sched.Next(getTime(test.time).Add(-1*time.Second), time.Time{})
+		actual := sched.Next(getTime(test.time).Add(-1 * time.Second))
 		expected := getTime(test.time)
 		if test.expected && expected != actual || !test.expected && expected == actual {
 			t.Errorf("Fail evaluating %s on %s: (expected) %s != %s (actual)",
@@ -191,7 +191,7 @@ func TestNext(t *testing.T) {
 			t.Error(err)
 			continue
 		}
-		actual := sched.Next(getTime(c.time), time.Time{})
+		actual := sched.Next(getTime(c.time))
 		expected := getTime(c.expected)
 		if !actual.Equal(expected) {
 			t.Errorf("%s, \"%s\": (expected) %v != %v (actual)", c.time, c.spec, expected, actual)
@@ -208,6 +208,9 @@ func TestNextAfterTime(t *testing.T) {
 		{"Mon Jul 9 14:45 2012", "0 0/15 * * * *", "Mon Jul 9 15:30 2012", "Mon Jul 9 15:45 2012"},
 		{"Mon Jul 9 14:59 2012", "0 0/15 * * * *", "Wed Jul 11 15:30 2012", "Wed Jul 11 15:45 2012"},
 		{"Mon Jul 9 14:59:59 2012", "0 0/15 * * * *", "Wed Jul 11 15:00 2012", "Wed Jul 11 15:15 2012"},
+
+		// Simple cases with same From and After values
+		{"Mon Jul 9 14:45 2012", "0 0/15 * * * *", "Mon Jul 9 14:45 2012", "Mon Jul 9 15:00 2012"},
 
 		// Wrap around hours
 		{"Mon Jul 9 15:45 2012", "0 20-35/15 * * * *", "Wed Jul 11 16:36 2012", "Wed Jul 11 17:20 2012"},
@@ -281,7 +284,7 @@ func TestNextAfterTime(t *testing.T) {
 			t.Error(err)
 			continue
 		}
-		actual := sched.Next(getTime(c.time), getTime(c.after))
+		actual := sched.NextWithAfter(getTime(c.time), getTime(c.after))
 		expected := getTime(c.expected)
 		if !actual.Equal(expected) {
 			t.Errorf("%s, \"%s\": (expected) %v != %v (actual)", c.time, c.spec, expected, actual)
@@ -354,7 +357,7 @@ func TestNextWithTz(t *testing.T) {
 			t.Error(err)
 			continue
 		}
-		actual := sched.Next(getTimeTZ(c.time), time.Time{})
+		actual := sched.Next(getTimeTZ(c.time))
 		expected := getTimeTZ(c.expected)
 		if !actual.Equal(expected) {
 			t.Errorf("%s, \"%s\": (expected) %v != %v (actual)", c.time, c.spec, expected, actual)


### PR DESCRIPTION

`Schedule.Next` method calculates the next activation time based on the provided `prev` time T1. However if prev T1 is too far away in the past the next value (T1 + delay) could still be in the past. This causes the activation to immediately trigger the job but the delay calculation based on prev will show a false spike. In order for Next to support returning a time closer to current time another argument is added which will be used to calculate the activation time and ensure it is later than the provided time. 

New definition:
```
type Schedule interface {
	Next(from, after time.Time) time.Time
}
```

## Testing
1. Added new supporting units tests for `ConstantDelay` and `Spec` based schedules.
2. Also tested on staging by disabling a destination and enabling after several delay periods. The next trigger time was set to future and calculated from previous trigger. https://segment.datadoghq.com/s/A9ih7c/a63-2tt-sbx

Staging schedule verification:
<img width="1386" alt="Screenshot 2023-04-27 at 4 53 34 PM" src="https://user-images.githubusercontent.com/118230101/235067032-ba685573-0c21-4a06-8772-29bd4a06d9be.png">
  

Old behaviour: Immediate trigger if destination enabled after a long pause

<img width="530" alt="Screenshot 2023-04-27 at 11 19 31 PM" src="https://user-images.githubusercontent.com/118230101/235207555-c27e4f4c-6aef-4109-8678-03d7bab6f282.png">